### PR TITLE
Fw preset workarounds

### DIFF
--- a/libdp100/PowerSupply.cs
+++ b/libdp100/PowerSupply.cs
@@ -260,7 +260,7 @@ namespace LibDP100
         {
             bool result = true;
 
-            if (Output.On)
+            if (Output.On || ActiveState.FaultStatus != PowerSupplyFaultStatus.OK)
             {
                 apiMutex.WaitOne();
                 NullStdOutput();

--- a/libdp100/PowerSupply.cs
+++ b/libdp100/PowerSupply.cs
@@ -394,6 +394,20 @@ namespace LibDP100
                 }
                 else
                 {
+                    if (index != Output.Preset)
+                    {
+                        // Mitigation measure for OCP false triggers.
+                        // This does not prevent it completely but avoids common occurrences.
+                        // The main continuing issue is seen when switching the output back ON
+                        // after changing to a more restrictive OCP setting when a VI setting
+                        // that is more demanding of current. Something inside the DP100
+                        // requires a settling time to stabilize and it seems like it can take
+                        // upwards to 2-3seconds.
+                        SetOutputOff();
+                        Output.Preset = index;
+                        Thread.Sleep(100);
+                    }
+
                     apiMutex.WaitOne();
                     NullStdOutput();
                     result = ApiInstance.UseGroup(


### PR DESCRIPTION
This resolves #17 , a potentially dangerous issue with either the AlientTek's DP100 DLL or their device FW v1.4.

However, this means there will be a limitation on using the CLI's `--preset` option while the device is in preset 0.

The following will not behave as a user may expect
```pwsh
vicon --preset 8
vicon --read-out
```

This will result in:
```output
Set Preset: 8
[ OUT_PARAMS ]
  State          : OFF
  Preset         : 0
  Setpoint
    Voltage (mV) : 8000
    Current (mA) : 1000
    OVP (mV)     : 9000
    OCP (mA)     : 800
```

The observed behavior is:
- Preset 8's voltage/current setpoints are loaded into the active output setpoint
- The active preset remains in preset 0
- The output state remains OFF

If it is desired for the preset value to actually change during the command the user must use the `--on` command.
However, a further stipulation here is that the `--on` command must be issued after setting `--preset` to a value between (inclusive) 1-9.

For example:

```pwsh
vicon --preset 8 --on
vicon --read-out
```

Once the device has left preset 0. The device behavior will follow a more logical behavior.