### PR TITLE
Dev

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             "program": "${workspaceFolder}/app/bin/Debug/net9.0/vicon",
-            "args": ["--interactive"],
+            "args": ["--interactive", "--check"],
             "cwd": "${workspaceFolder}",
             "stopAtEntry": false,
             "console": "integratedTerminal",

--- a/README.md
+++ b/README.md
@@ -364,5 +364,5 @@ This project is licensed under the MIT license. For more details please refer to
 [LICENSE](./LICENSE). This software depends on the following third party
 components:
 
-- Spectre.Console (https://github.com/spectreconsole/spectre.console/LICENSE.md)
+- Spectre.Console (https://github.com/spectreconsole/spectre.console/blob/main/LICENSE.md)
 - HidSharp (https://github.com/IntergatedCircuits/HidSharp/blob/master/License.txt)

--- a/app/AliasedDevice.cs
+++ b/app/AliasedDevice.cs
@@ -10,6 +10,9 @@ namespace PowerSupplyApp
         [JsonPropertyName("serial")]
         public string Serial { get; set; } = string.Empty;
 
+        [JsonPropertyName("config")]
+        public ConfiguredState? Config { get; set; }
+
         public override string ToString()
         {
             if (Alias == string.Empty)

--- a/app/ConfiguredState.cs
+++ b/app/ConfiguredState.cs
@@ -1,0 +1,56 @@
+using System.Text.Json.Serialization;
+using System.Security.Cryptography;
+using LibDP100;
+
+namespace PowerSupplyApp
+{
+    public class ConfiguredState
+    {
+        [JsonPropertyName("hash")]
+        public string Hash { get; set; } = string.Empty;
+
+        [JsonPropertyName("system-params")]
+        public PowerSupplySystemParams SystemParams { get; set; } = new();
+
+        [JsonPropertyName("presets")]
+        public List<PowerSupplySetpoint> Presets { get; set; } = [];
+
+        /// <summary>
+        /// The number of presets available on the device.
+        /// </summary>
+        public const byte NumPresets = 10;
+
+        public void Print()
+        {
+            SystemParams.Print();
+            foreach (var preset in Presets)
+            {
+                preset.Print();
+            }
+        }
+
+        public string ComputeConfiguredHash()
+        {
+            using var sha256 = SHA256.Create();
+            var sb = new System.Text.StringBuilder();
+
+            // Include settings critical for safe operation.
+            sb.Append(SystemParams.OPP);
+            sb.Append(SystemParams.OTP);
+            sb.Append(SystemParams.RPP);
+            sb.Append(SystemParams.AutoOn);
+            foreach (var preset in Presets)
+            {
+                sb.Append(preset.Voltage);
+                sb.Append(preset.Current);
+                sb.Append(preset.OVP);
+                sb.Append(preset.OCP);
+            }
+
+            // Compute the hash
+            var hashBytes = sha256.ComputeHash(System.Text.Encoding.UTF8.GetBytes(sb.ToString()));
+            return Convert.ToHexString(hashBytes);
+        }
+
+    }
+}

--- a/app/Operation.cs
+++ b/app/Operation.cs
@@ -3,6 +3,7 @@ namespace PowerSupplyApp
     public enum Operation
     {
         None,
+        Delay,
         ReadOutput,
         ReadActState,
         ReadSystem,

--- a/app/PowerControllerApp.csproj
+++ b/app/PowerControllerApp.csproj
@@ -48,4 +48,10 @@
     </EmbeddedResource>
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="vicon.settings.schema.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/app/ProcessArgs.cs
+++ b/app/ProcessArgs.cs
@@ -101,7 +101,7 @@ namespace PowerSupplyApp
         {
             if (!settings.Load())
             {
-                Console.WriteLine($"ERROR: Invalid settings, please correct." + Environment.NewLine + settings.GetUserSettingsFilePath());
+                ShowError("Invalid settings, please correct." + Environment.NewLine + settings.GetUserSettingsFilePath());
                 return ProcessArgsResult.Error;
             }
 
@@ -133,7 +133,7 @@ namespace PowerSupplyApp
                         case "--theme":
                             if ((i + 1 >= args.Length) || args[i + 1].StartsWith('-'))
                             {
-                                Console.WriteLine($"ERROR: Missing <THEME_NAME> parameter for '{args[i]}'.");
+                                ShowError($"Missing <THEME_NAME> parameter for '{args[i]}'.");
                                 return ProcessArgsResult.MissingParameter;
                             }
 
@@ -179,7 +179,7 @@ namespace PowerSupplyApp
 
                                 if (!result)
                                 {
-                                    Console.WriteLine($"ERROR: Invalid <MS_POLL> parameter for '{args[i]}'.");
+                                    ShowError($"Invalid <MS_POLL> parameter for '{args[i]}'.");
                                     return ProcessArgsResult.InvalidParameter;
                                 }
                             }
@@ -198,13 +198,13 @@ namespace PowerSupplyApp
                         case "--wavegen":
                             if ((i + 1 >= args.Length) || args[i + 1].StartsWith('-'))
                             {
-                                Console.WriteLine($"ERROR: Missing <FILE_PATH> parameter for '{args[i]}'.");
+                                ShowError($"Missing <FILE_PATH> parameter for '{args[i]}'.");
                                 return ProcessArgsResult.MissingParameter;
                             }
 
                             if (!WaveGen.Load(args[i + 1]))
                             {
-                                Console.WriteLine(WaveGen.GetLastErrorMessage());
+                                ShowError(WaveGen.GetLastErrorMessage());
                                 return ProcessArgsResult.Error;
                             }
                             break;
@@ -245,8 +245,8 @@ namespace PowerSupplyApp
                         default:
                             if (arg.StartsWith('-'))
                             {
-                                Console.WriteLine($"Unsupported argument '{arg}'." + Environment.NewLine +
-                                                  "Use -?, -h, or --help for help information.");
+                                ShowError($"Unsupported argument '{arg}'." + Environment.NewLine +
+                                          "Use -?, -h, or --help for help information.");
                                 return ProcessArgsResult.UnsupportedOption;
                             }
                             break;
@@ -265,7 +265,7 @@ namespace PowerSupplyApp
             {
                 if (!settings.Store())
                 {
-                    Console.WriteLine("Failed to store settings!");
+                    ShowError("Failed to store settings!");
                     return ProcessArgsResult.Error;
                 }
             }
@@ -290,7 +290,7 @@ namespace PowerSupplyApp
                     switch (arg)
                     {
                         default:
-                            Console.WriteLine($"Internal error: argument '{arg}' has not been implemented.");
+                            ShowError($"Internal - argument '{arg}' has not been implemented.");
                             return ProcessArgsResult.NotImplemented;
 
                         case "--json":
@@ -328,7 +328,7 @@ namespace PowerSupplyApp
                         case "--wavegen":
                             if (!WaveGen.Init(inst, sp) || !WaveGen.Restart())
                             {
-                                Console.WriteLine(WaveGen.GetLastErrorMessage());
+                                ShowError(WaveGen.GetLastErrorMessage());
                                 return ProcessArgsResult.Error;
                             }
 
@@ -376,7 +376,7 @@ namespace PowerSupplyApp
                             }
                             else
                             {
-                                Console.WriteLine($"ERROR: Missing <DELAY_MS> parameter for '{args[i]}'.");
+                                ShowError($"Missing <DELAY_MS> parameter for '{args[i]}'.");
                                 return ProcessArgsResult.MissingParameter;
                             }
                             break;
@@ -1155,7 +1155,7 @@ namespace PowerSupplyApp
             else
             {
                 // TODO improve, output each unprocessed arg.
-                Console.WriteLine($"Could not process '{args[index]}'");
+                ShowError($"Could not process '{args[index]}'");
                 return false;
             }
         }
@@ -1168,7 +1168,7 @@ namespace PowerSupplyApp
             }
             else
             {
-                Console.WriteLine($"Could not process '{arg}'");
+                ShowError($"Could not process '{arg}'");
                 return false;
             }
         }
@@ -1182,7 +1182,7 @@ namespace PowerSupplyApp
             }
             else
             {
-                Console.WriteLine($"Could not process '{args[index]}' ({args[index + 1]})");
+                ShowError($"Could not process '{args[index]}' ({args[index + 1]})");
                 return false;
             }
         }

--- a/app/ProcessArgs.cs
+++ b/app/ProcessArgs.cs
@@ -86,8 +86,8 @@ namespace PowerSupplyApp
                 "Sets the Over-Current Protection level. Please note, the current setpoint parameters will be used to update the currently configured preset. Reaching or exceeding this limit will switch the output OFF. (units: mA)");
             grid.AddRow("  [white]--opp[/]", "[silver]<DECI_W>[/]",
                 "Sets the Over-Power Protection level. Reaching or exceeding this limit will switch the output OFF. (units: 0.1 W, range: 0-1050)");
-            grid.AddRow("  [white]--otp[/]", "[silver]<DECI_C>[/]",
-                "Sets the Over-Temperature Protection level. Reaching or exceeding this limit will switch the output OFF. (units: 0.1 C, range: 500-800)");
+            grid.AddRow("  [white]--otp[/]", "[silver]<CELSIUS>[/]",
+                "Sets the Over-Temperature Protection level. Reaching or exceeding this limit will switch the output OFF. (units: 1 C, range: 50-80)");
             grid.AddRow("  [white]--rpp[/]", "[silver]<STATE>[/]",
                 "Sets the Reverse Polarity Protection. (range: 0-1)");
             grid.AddRow("  [white]--auto-on[/]", "[silver]<STATE>[/]",

--- a/app/ProcessArgs.cs
+++ b/app/ProcessArgs.cs
@@ -526,7 +526,7 @@ namespace PowerSupplyApp
 
         private static int ProcessWrite(PowerSupply inst, Operation op, string[] args, int index)
         {
-            bool result;
+            bool result = false;
             ushort parsedValue = 0;
             string formatMessage = string.Empty;
             int argsToProcess = 0;
@@ -548,6 +548,8 @@ namespace PowerSupplyApp
 
                 case Operation.UsePreset:
                     argsToProcess = 2;
+                    if (index + 1 >= args.Length) break;
+
                     result = ushort.TryParse(args[index + 1], out parsedValue);
                     if (result)
                     {
@@ -557,6 +559,8 @@ namespace PowerSupplyApp
 
                 case Operation.WriteVoltage:
                     argsToProcess = 2;
+                    if (index + 1 >= args.Length) break;
+
                     result = ushort.TryParse(args[index + 1], out parsedValue);
                     if (result)
                     {
@@ -571,6 +575,8 @@ namespace PowerSupplyApp
 
                 case Operation.WriteCurrent:
                     argsToProcess = 2;
+                    if (index + 1 >= args.Length) break;
+
                     result = ushort.TryParse(args[index + 1], out parsedValue);
                     if (result)
                     {
@@ -585,6 +591,8 @@ namespace PowerSupplyApp
 
                 case Operation.WriteOVP:
                     argsToProcess = 2;
+                    if (index + 1 >= args.Length) break;
+
                     result = ushort.TryParse(args[index + 1], out parsedValue);
                     if (result)
                     {
@@ -601,6 +609,8 @@ namespace PowerSupplyApp
 
                 case Operation.WriteOCP:
                     argsToProcess = 2;
+                    if (index + 1 >= args.Length) break;
+
                     result = ushort.TryParse(args[index + 1], out parsedValue);
                     if (result)
                     {
@@ -617,6 +627,8 @@ namespace PowerSupplyApp
 
                 case Operation.WriteOPP:
                     argsToProcess = 2;
+                    if (index + 1 >= args.Length) break;
+
                     result = ushort.TryParse(args[index + 1], out parsedValue);
                     if (result)
                     {
@@ -631,6 +643,8 @@ namespace PowerSupplyApp
 
                 case Operation.WriteOTP:
                     argsToProcess = 2;
+                    if (index + 1 >= args.Length) break;
+
                     result = ushort.TryParse(args[index + 1], out parsedValue);
                     if (result)
                     {
@@ -645,6 +659,8 @@ namespace PowerSupplyApp
 
                 case Operation.WriteRPP:
                     argsToProcess = 2;
+                    if (index + 1 >= args.Length) break;
+
                     result = ushort.TryParse(args[index + 1], out parsedValue);
                     if (result)
                     {
@@ -659,6 +675,8 @@ namespace PowerSupplyApp
 
                 case Operation.WriteAutoOn:
                     argsToProcess = 2;
+                    if (index + 1 >= args.Length) break;
+
                     result = ushort.TryParse(args[index + 1], out parsedValue);
                     if (result)
                     {
@@ -673,6 +691,8 @@ namespace PowerSupplyApp
 
                 case Operation.WriteVolume:
                     argsToProcess = 2;
+                    if (index + 1 >= args.Length) break;
+
                     result = ushort.TryParse(args[index + 1], out parsedValue);
                     if (result)
                     {
@@ -687,6 +707,8 @@ namespace PowerSupplyApp
 
                 case Operation.WriteBacklight:
                     argsToProcess = 2;
+                    if (index + 1 >= args.Length) break;
+
                     result = ushort.TryParse(args[index + 1], out parsedValue);
                     if (result)
                     {
@@ -702,13 +724,16 @@ namespace PowerSupplyApp
 
             if (!result)
             {
-                // TODO: more detailed error codes should be reported here for debugging purposes.
-                // Ex: "Not connected", "Out of Range", "Invalid command", "Invalid state"
-                SerializeObject(new CommandResponse
+                if (serializeAsJson)
                 {
-                    Command = op,
-                    Response = new { Error = "Operation Failed" }
-                });
+                    // TODO: more detailed error codes should be reported here for debugging purposes.
+                    // Ex: "Not connected", "Out of Range", "Invalid command", "Invalid state"
+                    SerializeObject(new CommandResponse
+                    {
+                        Command = op,
+                        Response = new { Error = "Operation Failed" }
+                    });
+                }
                 return 0;
             }
 
@@ -929,7 +954,7 @@ namespace PowerSupplyApp
 
             for (int i = index; i < args.Length; i++)
             {
-                if (args[i].StartsWith("--") || args[i].StartsWith('-'))
+                if (args[i].StartsWith('-'))
                 {
                     if (betweenFlags)
                     {

--- a/app/ProcessArgsResult.cs
+++ b/app/ProcessArgsResult.cs
@@ -10,6 +10,13 @@
         NotImplemented,
         MissingParameter,
         InvalidParameter,
-        UnsupportedOption
+        UnsupportedOption,
+        SerialNumberRequired,
+        DeviceNotPresent,
+        ConfigurationMismatch,
+        InitializationFailed,
+        NoAliasedDeviceFound,
+        NoConfigurationPresent,
+        StoreError
     }
 }

--- a/app/Program.cs
+++ b/app/Program.cs
@@ -1,10 +1,14 @@
 using LibDP100;
+using System.Security.Cryptography;
 
 namespace PowerSupplyApp
 {
     internal partial class Program
     {
         private static bool debug = false;
+        private static bool saveConfiguration = false;
+        private static bool loadConfiguration = false;
+        private static bool checkConfiguration = false;
         private static bool serializeAsJson = false;
         private static bool serializeAsJsonArray = false;
         private static int serializedOutput = 0;
@@ -36,7 +40,7 @@ namespace PowerSupplyApp
             if (psuCount == 0)
             {
                 ShowError("No DP100 detected!");
-                return 1;
+                return (int)ProcessArgsResult.DeviceNotPresent;
             }
 
             if ((psuSerialNumber == string.Empty) && (psuCount > 1))
@@ -50,7 +54,7 @@ namespace PowerSupplyApp
                 else
                 {
                     ShowError("Multiple DP100s detected. Please provide the --serial option!");
-                    return 1;
+                    return (int)ProcessArgsResult.SerialNumberRequired;
                 }
             }
 
@@ -68,16 +72,61 @@ namespace PowerSupplyApp
             // applications may connect to them.
             Enumerator.Done();
 
+            AliasedDevice? devSettings = null;
+
             if (psu != null)
             {
                 psu.GetDeviceInfo();
                 psu.GetSystemParams();
                 psu.Reload();
+
+                if (loadConfiguration || saveConfiguration || checkConfiguration)
+                {
+                    devSettings = settings.FindDeviceBySerialNumber(psu.Device.SerialNumber);
+                    if (devSettings == null)
+                    {
+                        return (int)ProcessArgsResult.NoAliasedDeviceFound;
+                    }
+                    else if (devSettings.Config == null)
+                    {
+                        return (int)ProcessArgsResult.NoConfigurationPresent;
+                    }
+                }
+
+                if (loadConfiguration)
+                {
+                    if (devSettings?.Config == null)
+                    {
+                        return (int)ProcessArgsResult.NoConfigurationPresent;
+                    }
+                    LoadConfiguration(psu, devSettings.Config);
+                    psu.Reload();
+                }
+
+                if (checkConfiguration)
+                {
+                    if (devSettings == null)
+                    {
+                        return (int)ProcessArgsResult.NoAliasedDeviceFound;
+                    }
+
+                    (string computedConfigHash, string computedDeviceHash, string recordedHash) = GetHashes(psu, devSettings);
+                    if ((recordedHash != computedConfigHash) || (recordedHash != computedDeviceHash))
+                    {
+                        ExitAlternateScreenBuffer();
+                        result = CheckConfiguration(psu, devSettings, computedConfigHash, computedDeviceHash, recordedHash);
+                        if (result != ProcessArgsResult.Ok)
+                        {
+                            return (int)result;
+                        }
+                        EnterAlternateScreenBuffer();
+                    }
+                }
             }
             else
             {
                 ShowError("Could not initialize DP100!");
-                return 1;
+                return (int)ProcessArgsResult.InitializationFailed;
             }
 
             // Only permit debug mode in non-interactive mode.
@@ -95,9 +144,231 @@ namespace PowerSupplyApp
 
             result = ProcessArgs(psu, args);
 
+            if (saveConfiguration && result == ProcessArgsResult.Ok)
+            {
+                if (devSettings == null)
+                {
+                    return (int)ProcessArgsResult.NoAliasedDeviceFound;
+                }
+
+                SaveConfiguration(psu, devSettings);
+            }
+
             psu.Disconnect();
 
             return (int)result;
+        }
+
+        private static (string computedConfigHash, string computedDeviceHash, string recordedHash) GetHashes(PowerSupply psu, AliasedDevice devSettings)
+        {
+            string computedConfigHash = devSettings.Config == null ? string.Empty : devSettings.Config.ComputeConfiguredHash();
+            string computedDeviceHash = GetConfigurationHash(psu.SystemParams, psu.Presets);
+            string recordedHash = devSettings.Config == null ? string.Empty : devSettings.Config.Hash;
+            return (computedConfigHash, computedDeviceHash, recordedHash);
+        }
+
+        private static ProcessArgsResult CheckConfiguration(PowerSupply psu, AliasedDevice devSettings, string computedConfigHash, string computedDeviceHash, string recordedHash)
+        {
+            ProcessArgsResult result = ProcessArgsResult.Ok;
+
+            if ((recordedHash == computedConfigHash) && (recordedHash == computedDeviceHash))
+            {
+                return result;
+            }
+
+            if (!interactiveMode)
+            {
+                ShowError("Configured state requires review!" + Environment.NewLine);
+                if (devSettings.Config == null)
+                {
+                    Console.WriteLine("No configuration has been saved to check against." + Environment.NewLine);
+                    Console.WriteLine("Possible actions:");
+                    Console.WriteLine("  1. Remove --check to skip the check and use the current device state.");
+                    Console.WriteLine("  2. Use --interactive to interactively resolve the the issue.");
+                    Console.WriteLine("  3. Use --save to save this configuration to disk.");
+                    result = ProcessArgsResult.NoConfigurationPresent;
+                }
+                else
+                {
+                    Console.WriteLine("The device state does not match saved configuration." + Environment.NewLine);
+                    Console.WriteLine("Possible actions:");
+                    Console.WriteLine("  1. Remove --check to skip the check and use the current device state.");
+                    Console.WriteLine("  2. Use --interactive to interactively resolve the the issue.");
+                    Console.WriteLine("  3. Use --save to save this configuration to disk.");
+                    Console.WriteLine("  4. Use --load to load the device state from disk.");
+                    result = ProcessArgsResult.ConfigurationMismatch;
+                }
+            }
+            else
+            {
+                ShowWarning("Configured state requires review!");
+            }
+
+            if (devSettings.Config != null)
+            {
+                Console.WriteLine();
+                Console.WriteLine($"Device Hash   : {computedDeviceHash}");
+                Console.WriteLine($"Recorded Hash : {(string.IsNullOrWhiteSpace(recordedHash) ? "None" : recordedHash)}");
+                Console.WriteLine($"Config Hash   : {(string.IsNullOrWhiteSpace(computedConfigHash) ? "None" : computedConfigHash)}");
+            }
+
+            if (recordedHash != computedConfigHash)
+            {
+                if (!string.IsNullOrWhiteSpace(recordedHash))
+                {
+                    Console.WriteLine();
+                    ShowWarning("Possible corruption detected in stored settings!");
+                }
+            }
+
+            if (computedConfigHash != computedDeviceHash)
+            {
+                Console.WriteLine();
+                PrintConfigurationDiff(psu, devSettings.Config);
+            }
+
+            if (result != ProcessArgsResult.Ok)
+            {
+                return result;
+            }
+
+            Console.WriteLine();
+
+            List<string> choices = ["Exit now", "Continue", "Save device state (to disk)"];
+            if (devSettings.Config != null)
+            {
+                choices.Add("Load device state (from disk)");
+            }
+
+            int choice = GetChoice("Select an action:", choices);
+            switch (choice)
+            {
+                default:
+                case 1: // Exit application, make no change.
+                    Console.WriteLine("Exiting.");
+                    return ProcessArgsResult.OkExitNow;
+                case 2: // Continue application, make no change.
+                    Console.WriteLine("Continuing.");
+                    return ProcessArgsResult.Ok;
+                case 3: // Save device state to disk
+                    if (!SaveConfiguration(psu, devSettings))
+                    {
+                        Console.WriteLine("Failed to store settings!");
+                        return ProcessArgsResult.StoreError;
+                    }
+                    Console.WriteLine("Saved configuration.");
+                    break;
+                case 4: // Load device state from disk.
+                    if (devSettings.Config == null)
+                    {
+                        return ProcessArgsResult.OkExitNow;
+                    }
+                    LoadConfiguration(psu, devSettings.Config);
+                    if (devSettings.Config.Hash != computedConfigHash)
+                    {
+                        // The settings appear to also need a corrected hash, save now.
+                        devSettings.Config.Hash = computedConfigHash;
+                        if (!SaveConfiguration(psu, devSettings))
+                        {
+                            Console.WriteLine("Failed to store settings!");
+                            return ProcessArgsResult.StoreError;
+                        }
+                    }
+                    Console.WriteLine("Loaded configuration.");
+                    break;
+            }
+
+            return ProcessArgsResult.Ok;
+        }
+
+        static bool SaveConfiguration(PowerSupply psu, AliasedDevice devSettings)
+        {
+            if (devSettings.Config == null)
+            {
+                devSettings.Config = new ConfiguredState();
+            }
+
+            devSettings.Config.SystemParams.OPP = psu.SystemParams.OPP;
+            devSettings.Config.SystemParams.OTP = psu.SystemParams.OTP;
+            devSettings.Config.SystemParams.RPP = psu.SystemParams.RPP;
+            devSettings.Config.SystemParams.AutoOn = psu.SystemParams.AutoOn;
+            devSettings.Config.SystemParams.Backlight = psu.SystemParams.Backlight;
+            devSettings.Config.SystemParams.Volume = psu.SystemParams.Volume;
+
+            devSettings.Config.Presets = new List<PowerSupplySetpoint>(psu.Presets.Length);
+            devSettings.Config.Presets.Clear();
+
+            for (int i = 0; i < psu.Presets.Length; i++)
+            {
+                devSettings.Config.Presets.Add(psu.Presets[i]);
+            }
+
+            devSettings.Config.Hash = devSettings.Config.ComputeConfiguredHash();
+            if (!settings.Save())
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        static void LoadConfiguration(PowerSupply psu, ConfiguredState? config)
+        {
+            if (config == null)
+            {
+                return;
+            }
+
+            psu.SetSystemParams(config.SystemParams);
+            foreach (var preset in config.Presets)
+            {
+                psu.SetPreset(preset.GetIndex(), preset);
+            }
+        }
+
+        // Prints all settings which do not match between device and config
+        static int PrintConfigurationDiff(PowerSupply psu, ConfiguredState? config)
+        {
+            if (config == null)
+            {
+                Console.WriteLine("Current device configuration:");
+                Console.WriteLine();
+                ShowConfiguration(psu.SystemParams, psu.Presets);
+                return 1;
+            }
+
+            Console.WriteLine("Checking configuration differences:");
+
+            int diffCount = ShowDifferences(psu, config);
+            if (diffCount == 0)
+            {
+                Console.WriteLine("- No differences found.");
+            }
+
+            return diffCount;
+        }
+
+        static string GetConfigurationHash(PowerSupplySystemParams systemParams, PowerSupplySetpoint[] presets)
+        {
+            using var sha256 = SHA256.Create();
+            var sb = new System.Text.StringBuilder();
+
+            // Include settings critical for safe operation.
+            sb.Append(systemParams.OPP);
+            sb.Append(systemParams.OTP);
+            sb.Append(systemParams.RPP);
+            sb.Append(systemParams.AutoOn);
+            foreach (var preset in presets)
+            {
+                sb.Append(preset.Voltage);
+                sb.Append(preset.Current);
+                sb.Append(preset.OVP);
+                sb.Append(preset.OCP);
+            }
+
+            // Compute the hash
+            var hashBytes = sha256.ComputeHash(System.Text.Encoding.UTF8.GetBytes(sb.ToString()));
+            return Convert.ToHexString(hashBytes);
         }
 
         private static int PrintEnumeration()

--- a/app/Program.cs
+++ b/app/Program.cs
@@ -35,7 +35,7 @@ namespace PowerSupplyApp
 
             if (psuCount == 0)
             {
-                Console.WriteLine("ERROR: No DP100 detected!");
+                ShowError("No DP100 detected!");
                 return 1;
             }
 
@@ -49,7 +49,7 @@ namespace PowerSupplyApp
                 }
                 else
                 {
-                    Console.WriteLine("ERROR: Multiple DP100s detected. Please provide the --serial option!");
+                    ShowError("Multiple DP100s detected. Please provide the --serial option!");
                     return 1;
                 }
             }
@@ -76,7 +76,7 @@ namespace PowerSupplyApp
             }
             else
             {
-                Console.WriteLine("ERROR: Could not initialize DP100!");
+                ShowError("Could not initialize DP100!");
                 return 1;
             }
 

--- a/app/TUI/Model.cs
+++ b/app/TUI/Model.cs
@@ -9,7 +9,7 @@ namespace PowerSupplyApp
         private const ushort powerOutputMax = 1050; // 1050 * 0.1 = 105W
         private const ushort powerOutputMin = 0;
         private const ushort tempOutputMax = 80; // 50 = 50C
-        private const ushort tempOutputMin = 0;
+        private const ushort tempOutputMin = 50;
 
         private static int VoltageOutput
         {

--- a/app/TUI/View.cs
+++ b/app/TUI/View.cs
@@ -84,12 +84,13 @@ namespace PowerSupplyApp
         /// </summary>
         private static void EnterAlternateScreenBuffer()
         {
+            // Hide cursor.
+            Console.Write($"{(char)27}[?25l");
             if (!interactiveMode || altBufferState)
                 return;
 
-            // Enter alt-screen buffer and hide cursor.
+            // Enter alt-screen buffer.
             Console.Write($"{(char)27}[?1049h");
-            Console.Write($"{(char)27}[?25l");
             altBufferState = true;
         }
 
@@ -105,7 +106,6 @@ namespace PowerSupplyApp
             Console.Write($"{(char)27}[?1049l");
             Console.Write($"{(char)27}[?25h");
             altBufferState = false;
-
         }
 
         /// <summary>

--- a/app/TUI/View.cs
+++ b/app/TUI/View.cs
@@ -99,6 +99,24 @@ namespace PowerSupplyApp
         }
 
         /// <summary>
+        /// Shows a warning message.
+        /// </summary>
+        /// <param name="message">The message to show.</param>
+        private static void ShowWarning(string message)
+        {
+            AnsiConsole.Write(new Markup($"[yellow]WARNING[/] {message}{Environment.NewLine}"));
+        }
+
+        /// <summary>
+        /// Shows an error message.
+        /// </summary>
+        /// <param name="message">The message to show.</param>
+        private static void ShowError(string message)
+        {
+            AnsiConsole.Write(new Markup($"[white on darkred] ERROR [/] {message}{Environment.NewLine}"));
+        }
+
+        /// <summary>
         /// Gets the Grid for the device information.
         /// </summary>
         /// <param name="info">Power supply device information.</param>

--- a/app/vicon.settings.schema.json
+++ b/app/vicon.settings.schema.json
@@ -1,0 +1,109 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "poll-rate-ms": {
+            "type": "integer",
+            "minimum": 0
+        },
+        "theme": {
+            "type": "string",
+            "enum": ["classic", "black-and-white", "grey", "dark-red", "dark-green", "dark-magenta", "cyan", "gold", "blue", "blue-violet"]
+        },
+        "devices": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "alias": {
+                        "type": "string"
+                    },
+                    "serial": {
+                        "type": "string",
+                        "pattern": "^[0-9A-Fa-f]{8}$"
+                    },
+                    "config": {
+                        "type": "object",
+                        "properties": {
+                            "hash": {
+                                "type": "string",
+                                "pattern": "^[0-9A-Fa-f]*$"
+                            },
+                            "system-params": {
+                                "type": "object",
+                                "properties": {
+                                    "opp": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "maximum": 1050
+                                    },
+                                    "otp": {
+                                        "type": "integer",
+                                        "minimum": 50,
+                                        "maximum": 80
+                                    },
+                                    "rpp": {
+                                        "type": "boolean"
+                                    },
+                                    "auto-on": {
+                                        "type": "boolean"
+                                    },
+                                    "backlight": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "maximum": 4
+                                    },
+                                    "volume": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "maximum": 4
+                                    }
+                                },
+                                "required": ["opp","otp","rpp","auto-on","backlight","volume"],
+                                "additionalProperties": false
+                            },
+                            "presets": {
+                                "type":"array",
+                                "minItems": 10,
+                                "maxItems": 10,
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "voltage": {
+                                            "type": "integer",
+                                            "minimum": 0,
+                                            "maximum": 30500
+                                        },
+                                        "current": {
+                                            "type": "integer",
+                                            "minimum": 0,
+                                            "maximum": 5050
+                                        },
+                                        "ovp": {
+                                            "type": "integer",
+                                            "minimum": 0,
+                                            "maximum": 30500
+                                        },
+                                        "ocp": {
+                                            "type": "integer",
+                                            "minimum": 0,
+                                            "maximum": 5050
+                                        }
+                                    },
+                                    "required": ["voltage","current","ovp","ocp"],
+                                    "additionalProperties": false
+                                }
+                            }
+                        },
+                        "required": ["hash","system-params","presets"],
+                        "additionalProperties": false
+                    }
+                },
+                "required": ["alias", "serial"],
+                "additionalProperties": false
+            }
+        }
+    },
+    "required": [],
+    "additionalProperties": false
+}

--- a/libdp100/PowerSupply.cs
+++ b/libdp100/PowerSupply.cs
@@ -765,6 +765,11 @@ namespace LibDP100
                 return PowerSupplyResult.DeviceNotConnected;
             }
 
+            if (preset >= NumPresets)
+            {
+                return PowerSupplyResult.OutOfRange;
+            }
+
             PowerSupplyResult result = PowerSupplyResult.OK;
 
             if (!presetsValid[preset])
@@ -794,6 +799,11 @@ namespace LibDP100
             if (!Connected)
             {
                 return PowerSupplyResult.DeviceNotConnected;
+            }
+
+            if (preset >= NumPresets)
+            {
+                return PowerSupplyResult.OutOfRange;
             }
 
             PowerSupplyResult result = PowerSupplyResult.OK;
@@ -844,6 +854,11 @@ namespace LibDP100
                 return PowerSupplyResult.DeviceNotConnected;
             }
 
+            if (preset >= NumPresets)
+            {
+                return PowerSupplyResult.OutOfRange;
+            }
+
             PowerSupplyResult result = PowerSupplyResult.OK;
 
             if (!presetsValid[preset])
@@ -880,6 +895,11 @@ namespace LibDP100
             if (!Connected)
             {
                 return PowerSupplyResult.DeviceNotConnected;
+            }
+
+            if (preset >= NumPresets)
+            {
+                return PowerSupplyResult.OutOfRange;
             }
 
             PowerSupplyResult result = PowerSupplyResult.OK;
@@ -1025,6 +1045,11 @@ namespace LibDP100
             if (!Connected)
             {
                 return PowerSupplyResult.DeviceNotConnected;
+            }
+
+            if (preset >= NumPresets)
+            {
+                return PowerSupplyResult.OutOfRange;
             }
 
             byte[] outputReport = GetBasicSetCommand(BasicSetSubOpCode.GetGroupInfo, preset);

--- a/libdp100/PowerSupply.cs
+++ b/libdp100/PowerSupply.cs
@@ -533,11 +533,16 @@ namespace LibDP100
                 if (Presets[Output.Preset] == null)
                 {
                     Presets[Output.Preset] = new PowerSupplySetpoint(Output.Preset);
+                    result = GetPreset(Output.Preset);
                 }
+            }
 
+            if (result == PowerSupplyResult.OK)
+            {
                 // Output state affects the volatile state of a preset (group).
-                Presets[Output.Preset].Copy(Output.Setpoint);
-                presetsValid[Output.Preset] = true;
+                // This does not include OVP/OCP.
+                Presets[Output.Preset].Voltage = Output.Setpoint.Voltage;
+                Presets[Output.Preset].Current = Output.Setpoint.Current;
             }
 
             return result;

--- a/libdp100/PowerSupplySetpoint.cs
+++ b/libdp100/PowerSupplySetpoint.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace LibDP100
 {
     /// <summary>
@@ -8,27 +10,36 @@ namespace LibDP100
         /// <summary>
         /// Output voltage. Unit: mV
         /// </summary>
+        [JsonPropertyName("voltage")]
         public ushort Voltage { get; set; } = 0;
 
         /// <summary>
         /// Output current. Unit: mA
         /// </summary>
+        [JsonPropertyName("current")]
         public ushort Current { get; set; } = 0;
 
         /// <summary>
         /// Over voltage protection. Unit: mV.
         /// </summary>
+        [JsonPropertyName("ovp")]
         public ushort OVP { get; set; } = 0;
 
         /// <summary>
         /// Over current protection. Unit: mA.
         /// </summary>
+        [JsonPropertyName("ocp")]
         public ushort OCP { get; set; } = 0;
 
         /// <summary>
         /// The index associated with the preset.
         /// </summary>
         private byte Index { get; set; } = 0;
+
+        /// <summary>
+        /// Default constructor. Not to be used except for deserialization.
+        /// </summary>
+        public PowerSupplySetpoint() { }
 
         /// <summary>
         /// Default constructor.
@@ -74,6 +85,16 @@ namespace LibDP100
         public byte GetIndex()
         {
             return Index;
+        }
+
+        /// <summary>
+        /// Sets the index of the preset.
+        /// This is primarily intended for deserialization logic.
+        /// </summary>
+        /// <param name="index">The index to set.</param>
+        public void SetIndex(byte index)
+        {
+            Index = index;
         }
 
         /// <summary>

--- a/libdp100/PowerSupplySystemParams.cs
+++ b/libdp100/PowerSupplySystemParams.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace LibDP100
 {
     /// <summary>
@@ -8,31 +10,37 @@ namespace LibDP100
         /// <summary>
         /// Over power protection. Unit: 0.1W.
         /// </summary>
+        [JsonPropertyName("opp")]
         public ushort OPP { get; set; } = 0;
 
         /// <summary>
-        /// Over temperature protection. Unit Celsius. Value range 50-80.
+        /// Over temperature protection. Unit Celsius. Value range 40-80.
         /// </summary>
+        [JsonPropertyName("otp")]
         public ushort OTP { get; set; } = 0;
 
         /// <summary>
         /// Reverse polarity protection enable/disable.
         /// </summary>
+        [JsonPropertyName("rpp")]
         public bool RPP { get; set; } = false;
 
         /// <summary>
         /// Enable/Disable automatic output-on.
         /// </summary>
+        [JsonPropertyName("auto-on")]
         public bool AutoOn { get; set; } = false;
 
         /// <summary>
         /// Backlight level value 0-4.
         /// </summary>
+        [JsonPropertyName("backlight")]
         public byte Backlight { get; set; } = 0;
 
         /// <summary>
         /// Volume level ranges from 0-4.
         /// </summary>
+        [JsonPropertyName("volume")]
         public byte Volume { get; set; } = 0;
 
         /// <summary>

--- a/publish/build-installer.iss
+++ b/publish/build-installer.iss
@@ -42,6 +42,7 @@ Source: "build\win-x64\Spectre.Console.dll"; DestDir: "{app}\bin"; Flags: ignore
 Source: "build\win-x64\vicon.dll"; DestDir: "{app}\bin"; Flags: ignoreversion
 Source: "build\win-x64\vicon.exe"; DestDir: "{app}\bin"; Flags: ignoreversion
 Source: "build\win-x64\vicon.runtimeconfig.json"; DestDir: "{app}\bin"; Flags: ignoreversion
+Source: "build\win-x64\vicon.settings.schema.json"; DestDir: "{app}\bin"; Flags: ignoreversion
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
 [Code]


### PR DESCRIPTION
Notable changes:
* Adds a consistency check including hash and non-volatile configured state into to aliased devices.
* An aliased device can be created via `--serial <serial_number> "my_alias"`
* Fixed additional regression in #40.
* Improved error reporting behavior. While far from perfect, error reporting has been improved to better respect the --json argument. This however there are other edge cases like invalid/unknown arguments which are not part of the command processor and will still output non-json output. A future update may address this but is not a particularly high priority.